### PR TITLE
fix: rework the action script

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,8 +23,7 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: "0"
-        ref: ${{ steps.validate.outputs.build-tag }}
-        token: ${{ secrets.GH_ACCESS_TOKEN }}
+        ref: "main"
 
     - name: Clone governance repo
       run: |


### PR DESCRIPTION
Rework the `action.yaml` file to pull in the whole governance repo and parse through to find only the specific file.