### PR TITLE
fix: change custom_properties.json to repo-properties.yaml in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ jobs:
 
 ---
 
-## Example custom_props.json
+## Example repo-properties.yaml
 
-`custom_props.json`:
+`repo-properties.yaml`:
 ```yaml
 org: PandasWhoCode
 repositories:


### PR DESCRIPTION
**Description**:

Change the (incorrect) custom_properties.json to repo-properties.yaml in the README file.

**Related Issue(s)**:

Fixes #18