### PR TITLE
feat: add new sleep length parameter to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ fine-grained token with the following permissions:
 ## 📦 Inputs
 
 | Name                   | Description                                                                                           | Required | Default                |
-|------------------------|-------------------------------------------------------------------------------------------------------|----------|------------------------|
-| `token`                | GitHub Personal Access Token (Fine-Grained with: Repository custom properties `Read and Write` scope) | ✅ Yes    | —                      |
-| `repo-properties.yaml` | File should be located in the root-level directory.                                                   | ✅ Yes    | `repo-properties.yaml` |
-| `sleep-length`         | Time (seconds) to sleep between API calls                                                             | :x: No   | `1 second`             
+|------------------------|-------------------------------------------------------------------------------------------------------|-------|------------------------|
+| `token`                | GitHub Personal Access Token (Fine-Grained with: Repository custom properties `Read and Write` scope) | ✅ Yes | —                      |
+| `repo-properties.yaml` | File should be located in the root-level directory.                                                   | ✅ Yes | `repo-properties.yaml` |
+| `sleep-length`         | Time (seconds) to sleep between API calls                                                             | ❌ No   | `1 second`             
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ fine-grained token with the following permissions:
 |------------------------|-------------------------------------------------------------------------------------------------------|----------|------------------------|
 | `token`                | GitHub Personal Access Token (Fine-Grained with: Repository custom properties `Read and Write` scope) | ✅ Yes    | —                      |
 | `repo-properties.yaml` | File should be located in the root-level directory.                                                   | ✅ Yes    | `repo-properties.yaml` |
+| `sleep-length`         | Time (seconds) to sleep between API calls                                                             | :x: No   | `1 second`             
 
 ---
 
@@ -54,6 +55,7 @@ jobs:
       - uses: PandasWhoCode/update-custom-properties@v1
         with:
           token: ${{ secrets.GH_CUSTOM_PROPERTIES_TOKEN }}
+          sleep-length: 5
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
       - uses: PandasWhoCode/update-custom-properties@v1
         with:
           token: ${{ secrets.GH_CUSTOM_PROPERTIES_TOKEN }}
-          sleep-length: 5
+          sleep-length: '5'
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ fine-grained token with the following permissions:
 
 | Name                   | Description                                                                                           | Required | Default                |
 |------------------------|-------------------------------------------------------------------------------------------------------|-------|------------------------|
-| `token`                | GitHub Personal Access Token (Fine-Grained with: Repository custom properties `Read and Write` scope) | ✅ Yes | —                      |
-| `repo-properties.yaml` | File should be located in the root-level directory.                                                   | ✅ Yes | `repo-properties.yaml` |
-| `sleep-length`         | Time (seconds) to sleep between API calls                                                             | ❌ No   | `1 second`             
+| `token`                | GitHub Personal Access Token (Fine-Grained with: Repository custom properties `Read and Write` scope) | ✅  | —                      |
+| `repo-properties.yaml` | File should be located in the root-level directory.                                                   | ✅  | `repo-properties.yaml` |
+| `sleep-length`         | Time (seconds) to sleep between API calls                                                             | -   | `1 second`             
 
 ---
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
   sleep-length:
     description: 'Time to sleep (sec) between API calls'
     required: false
-    default: 1
+    default: '1'
 
 runs:
   using: "composite"
@@ -90,7 +90,6 @@ runs:
             fi
             # API Call here
             gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${ORG_NAME}/${REPO_NAME}/properties/values -f "properties[][property_name]=${key}" -f "properties[][value]=${value}"
-            echo "Now sleeping for ${SLEEP_LENGTH}"
             sleep "${SLEEP_LENGTH}"
           done
         done < "${REPO_NAMES_FILE}"

--- a/action.yaml
+++ b/action.yaml
@@ -90,6 +90,7 @@ runs:
             fi
             # API Call here
             gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${ORG_NAME}/${REPO_NAME}/properties/values -f "properties[][property_name]=${key}" -f "properties[][value]=${value}"
+            echo "Now sleeping for ${SLEEP_LENGTH}"
             sleep "${SLEEP_LENGTH}"
           done
         done < "${REPO_NAMES_FILE}"

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,10 @@ inputs:
   token:
     description: 'Personal Access Token'
     required: true
+  sleep-length:
+    description: 'Time to sleep (sec) between API calls'
+    required: false
+    default: 1
 
 runs:
   using: "composite"
@@ -38,6 +42,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        SLEEP_LENGTH: ${{ inputs.sleep-length }}
       run: |
         # Input files
         REPO_NAMES_FILE="repo-names.txt"
@@ -85,6 +90,7 @@ runs:
             fi
             # API Call here
             gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${ORG_NAME}/${REPO_NAME}/properties/values -f "properties[][property_name]=${key}" -f "properties[][value]=${value}"
+            sleep "${SLEEP_LENGTH}"
           done
         done < "${REPO_NAMES_FILE}"
         echo "Successfully set custom properties!"

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
   sleep-length:
     description: 'Time to sleep (sec) between API calls'
     required: false
-    default: '1'
+    default: '0'
 
 runs:
   using: "composite"


### PR DESCRIPTION
**Description**:

This PR adds a new flag to allow for sleeping between each API call to avoid rate limiting.

**Related Issue(s)**:

Implements #21

**Testing**:

Verbose testing completed [here](https://github.com/hashgraph/governance/actions/runs/17982423905/job/51151826887).